### PR TITLE
Rename scss-lint to scss_lint.

### DIFF
--- a/project_template/Gemfile
+++ b/project_template/Gemfile
@@ -4,5 +4,5 @@ group :development, :test do
   gem 'rspec'
   gem 'capybara'
   gem 'poltergeist'
-  gem 'scss-lint'
+  gem 'scss_lint'
 end


### PR DESCRIPTION
Fix warning about scss-lint rename.

 $ bundle
 WARNING: `scss-lint` has been renamed to `scss_lint` to follow proper RubyGems naming conventions. Update your Gemfile or relevant install scripts to install `scss_lint`.
