### PR TITLE
Add a polyfill for Function.bind in Phantomjs

### DIFF
--- a/project_template/spec/spec_helper.rb
+++ b/project_template/spec/spec_helper.rb
@@ -10,6 +10,10 @@ RSpec.configure do |config|
   config.order = 'random'
 end
 
+Capybara.register_driver :poltergeist do |app|
+  Capybara::Poltergeist::Driver.new(app, {extensions: ['spec/support/function_bind_polyfill.js']})
+end
+
 Capybara.default_driver = :poltergeist
 
 if ENV['PRE_BUILT']

--- a/project_template/spec/support/function_bind_polyfill.js
+++ b/project_template/spec/support/function_bind_polyfill.js
@@ -1,0 +1,27 @@
+// This is needed because phantomjs 1.x doesnt support Function.protoype.bind
+// source https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind?redirectlocale=en-US&redirectslug=JavaScript%2FReference%2FGlobal_Objects%2FFunction%2Fbind#Compatibility
+
+if (!Function.prototype.bind) {
+  Function.prototype.bind = function (oThis) {
+    if (typeof this !== "function") {
+      // closest thing possible to the ECMAScript 5
+      // internal IsCallable function
+      throw new TypeError("Function.prototype.bind - what is trying to be bound is not callable");
+    }
+
+    var aArgs = Array.prototype.slice.call(arguments, 1),
+        fToBind = this, 
+        fNOP = function () {},
+        fBound = function () {
+          return fToBind.apply(this instanceof fNOP && oThis
+                 ? this
+                 : oThis,
+                 aArgs.concat(Array.prototype.slice.call(arguments)));
+        };
+
+    fNOP.prototype = this.prototype;
+    fBound.prototype = new fNOP();
+
+    return fBound;
+  };
+}


### PR DESCRIPTION
This addresses an issue @stefanvr was having; when running rspec against a livereload enabled server (or you're using any library that uses `Function.bind`) rspec will fail with the following error:

```
  1) Hello world shows a greeting
     Failure/Error: visit '/index.html'
     Capybara::Poltergeist::JavascriptError:
       One or more errors were raised in the Javascript code on the page. If you don't care about these errors, you can ignore them by setting js_errors: false in your Poltergeist configuration (see documentation for details).

       TypeError: 'undefined' is not a function (evaluating 'this.window.console.error.bind(this.window.console)')
       TypeError: 'undefined' is not a function (evaluating 'this.window.console.error.bind(this.window.console)')
           at http://localhost:35729/livereload.js?snipver=1:301 in LiveReload
           at http://localhost:35729/livereload.js?snipver=1:1111
           at http://localhost:35729/livereload.js?snipver=1:1137
           at http://localhost:35729/livereload.js?snipver=1:1 in s
           at http://localhost:35729/livereload.js?snipver=1:1 in e
           at http://localhost:35729/livereload.js?snipver=1:1183
     # ./spec/features/welcome_spec.rb:5:in `block (2 levels) in <top (required)>'
```

This is due to the fact that Phantomjs 1.x doesn't support `Function.bind`. This PR adds a polyfill that will add `Function.bind` if it's not available.

Note that Phantomjs 2.x **does** support `Function.bind` so you won't have this issue if you're on Phantomjs 2.x. Phantomjs 2.x is however still in it's infancy, specially with Linux support.