### PR TITLE
Feature/fix scss lint errors

### DIFF
--- a/project_template/app/styles/application.scss
+++ b/project_template/app/styles/application.scss
@@ -34,7 +34,7 @@ a, a:active, a:hover, a:visited {
   top: 0px;
 
   z-index: 2;
-  background: #fff;
+  background: $color-page-background;
 
   &.animated .header, &.slideout {
     position: absolute;

--- a/project_template/app/styles/application.scss
+++ b/project_template/app/styles/application.scss
@@ -19,7 +19,7 @@ html, body {
 
 a, a:active, a:hover, a:visited {
   text-decoration: none;
-  color: #000;
+  color: $color-link;
 }
 
 #maji-app {

--- a/project_template/app/styles/application.scss
+++ b/project_template/app/styles/application.scss
@@ -105,7 +105,7 @@ a, a:active, a:hover, a:visited {
     position: relative;
     padding: 10px 15px;
 
-    border-bottom: 1px solid #e8e8e8;
+    border-bottom: 1px solid $color-listview-li-border;
 
     &:after {
       font-size: 12px;

--- a/project_template/app/styles/fonts/lato.scss
+++ b/project_template/app/styles/fonts/lato.scss
@@ -1,6 +1,6 @@
-/**
- * Font files can be found in /public/assets/fonts
- */
+//
+// Font files can be found in /public/assets/fonts
+//
 @font-face {
   font-family: 'Lato';
   font-style: normal;

--- a/project_template/app/styles/variables.scss
+++ b/project_template/app/styles/variables.scss
@@ -10,3 +10,4 @@ $color-form-input-border-focus: #b5b5b5;
 
 $color-link: #000;
 $color-page-background: #fff;
+$color-listview-li-border: #e8e8e8;

--- a/project_template/app/styles/variables.scss
+++ b/project_template/app/styles/variables.scss
@@ -9,3 +9,4 @@ $color-form-input-border: #ccc;
 $color-form-input-border-focus: #b5b5b5;
 
 $color-link: #000;
+$color-page-background: #fff;

--- a/project_template/app/styles/variables.scss
+++ b/project_template/app/styles/variables.scss
@@ -7,3 +7,5 @@ $color-header-text: #fff;
 $color-form-input-bg: #fff;
 $color-form-input-border: #ccc;
 $color-form-input-border-focus: #b5b5b5;
+
+$color-link: #000;


### PR DESCRIPTION
When you create a new maji app and run bin/ci you get scss-lint errors/warnings. This PR fixes the scss lint errors.

    $ ./bin/maji new org.my-company.maji-test maji-test
    $ cd maji-test
    ...
    app/styles/application.scss:22 [W] ColorVariable: Color literals like `#000` should only be used in variable declarations; they should be referred to via variable everywhere else.
    app/styles/application.scss:37 [W] ColorVariable: Color literals like `#fff` should only be used in variable declarations; they should be referred to via variable everywhere else.
    app/styles/application.scss:108 [W] ColorVariable: Color literals like `#e8e8e8` should only be used in variable declarations; they should be referred to via variable everywhere else.
    app/styles/fonts/lato.scss:1 [W] Comment: Use `//` comments everywhere

    $ echo $?
    1

