### PR TITLE
Lock Gem versions in project template

### DIFF
--- a/project_template/Gemfile
+++ b/project_template/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
 group :development, :test do
-  gem 'rspec'
-  gem 'capybara'
-  gem 'poltergeist'
-  gem 'scss_lint'
+  gem 'rspec', '~> 3.2.0'
+  gem 'capybara', '~> 2.4.4'
+  gem 'poltergeist', '~> 1.6.0'
+  gem 'scss_lint', '0.38.0'
 end


### PR DESCRIPTION
This came up in #46.

With this PR new generated projects will always use the latest gem
version within the major version we've specified. If a gem upgrades to a
new major version we should check for compatibility because it may break
the setup.

Note that scss_lint is fixed to the current version specifically, since
each new version may introduce new checker rules which could break with
the project template's scss files.