### PR TITLE
Add FAQ entry for Marionette.inspector

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ A Maji Mobile App comes with several frameworks built-in and configured to work 
  * [MochaJS](http://mochajs.org) a JavaScript testing framework that supports a BDD style of writing tests
  * [Chai](http://chaijs.com) is an assertion library that enables a BDD style of developing
 
+### FAQ
+
+For our Frequently Asked Questions, see [here](docs/faq.md).
+
 ### Documentation
 
 Here are some links to documentation you might need:
@@ -108,8 +112,6 @@ Here are some links to documentation you might need:
  * [Mocha](http://mochajs.org/#assertions)
  * [Chai Expect/Should](http://chaijs.com/api/bdd/)
  * [Apache Cordova](http://cordova.apache.org/docs/en/4.0.0/)
-
-There is also a [Maji Mobile FAQ](docs/faq.md).
 
 
 ## License

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -45,4 +45,4 @@ See the [Cordova Plugin API](http://docs.phonegap.com/en/4.0.0/cordova_plugins_p
 
 ## Can I use the [marionette.inspector](https://github.com/marionettejs/marionette.inspector) to inspect my Maji App?
 
-Yes you can, but note that we use Broweserify in Maji App, so please note the [caveats](https://github.com/marionettejs/marionette.inspector#caveats) section.
+Yes you can, but note that Maji apps use Broweserify, so please note the [Marionette Inspector caveats](https://github.com/marionettejs/marionette.inspector#caveats) section.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -42,3 +42,7 @@ Apache Cordova is easily configurable to create a Mobile Application that uses e
 You can access any mobile device features by adding the corresponding plug-in, either one created by Apache or one of the many plug-ins made by the active community.
 
 See the [Cordova Plugin API](http://docs.phonegap.com/en/4.0.0/cordova_plugins_pluginapis.md.html) for more details.
+
+## Can I use the [marionette.inspector](https://github.com/marionettejs/marionette.inspector) to inspect my Maji App?
+
+Yes you can, but note that we use Broweserify in Maji App, so please note the [caveats](https://github.com/marionettejs/marionette.inspector#caveats) section.


### PR DESCRIPTION
Mention how you use the Chrome Extension [marionette.inspector](http://github.com/marionettejs/marionette.inspector) in a Maji App.

Reported by @kjwierenga 