### PR TITLE
Update README to instruct to install Maji develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Before you can use Maji, make sure you have the following:
 To create a new app execute the following commands in your shell:
 
 ```
-$ npm install git://github.com/kabisaict/maji.git
+$ npm install kabisaict/maji#develop
 $ ./node_modules/.bin/maji new org.example.my-app /desired/path/to/your/project/
 $ cd /desired/path/to/your/project/
 $ bin/setup

--- a/project_template/package.json
+++ b/project_template/package.json
@@ -14,7 +14,7 @@
     "jquery": "~2.1.3",
     "underscore": ">=1.6.0",
     "bugsnag-js": "2.4.7",
-    "maji": "git://github.com/kabisaict/maji.git"
+    "maji": "kabisaict/maji#develop"
   },
   "devDependencies": {
     "autoprefixer": "^5.1.0",


### PR DESCRIPTION
As long as we don't have an official release out people should just install the latest and greatest from develop. This PR changes the README to reflect that.