### PR TITLE
Add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.0",
   "main": "lib/index.js",
   "bin" : { "maji" : "./lib/cli.js" },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kabisaict/maji"
+  },
   "devDependencies": {
     "coffee-script": "1.9.0"
   },


### PR DESCRIPTION
This get rids of the following warning when npm installing maji:

npm WARN package.json maji@1.0.0 No repository field.