### PR TITLE
Replace autoprefixer cli with postcss-cli

### DIFF
--- a/project_template/Makefile
+++ b/project_template/Makefile
@@ -34,7 +34,7 @@ build-js:
 		app/application.coffee | exorcist $(DIST_DIR)/assets/app.js.map | sed '/^\s*$$/d' > $(DIST_DIR)/assets/app.js
 
 build-css:
-	node-sass --stdout --output-style $${CSS_OUTPUT_STYLE:-compressed} --include-path vendor/styles app/styles/application.scss | autoprefixer -b 'ios >= 8, android >= 4, ie >=10' > $(DIST_DIR)/assets/app.css
+	node-sass --stdout --output-style $${CSS_OUTPUT_STYLE:-compressed} --include-path vendor/styles app/styles/application.scss | postcss --use autoprefixer --autoprefixer.browsers 'ios >= 8, android >= 4, ie >=10' > $(DIST_DIR)/assets/app.css
 
 build-icons:
 	DIST_DIR='$(DIST_DIR)' node script/build-iconfont.js

--- a/project_template/package.json
+++ b/project_template/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "autoprefixer": "^5.1.0",
+    "postcss-cli": "^1.3.1",
     "brfs": "^1.3.0",
     "browserify": "^8.1.3",
     "coffeeify": "^1.0.0",


### PR DESCRIPTION
Fixes 'Autoprefixer CLI is deprecated. Use postcss-cli instead.' during build.