### PR TITLE
Add aliasify. Gets rid of pesky relative requires.

### DIFF
--- a/project_template/Makefile
+++ b/project_template/Makefile
@@ -26,6 +26,7 @@ build-js:
 	browserify --extension .hamlc --extension .coffee \
 		-g uglifyify \
 		-t coffeeify \
+		-t aliasify \
 		-t yamlify \
 		-t [ haml-coffee-browserify ] \
 		-t [ envify purge ] \
@@ -52,6 +53,7 @@ serve: check-server-port clean build-statics build-icons build-css livereload
 	onchange 'app/styles/icons/*.svg' -- make build-icons &
 	watchify -v --extension .hamlc --extension .coffee \
 	 -t coffeeify \
+	 -t aliasify \
 	 -t yamlify \
 	 -t [ haml-coffee-browserify ] \
 	 -t [ envify purge ] \

--- a/project_template/app/modules/home/home_app.coffee
+++ b/project_template/app/modules/home/home_app.coffee
@@ -1,4 +1,4 @@
-app        = require('../../app')
+app        = require('app/app')
 Marionette = require('backbone.marionette')
 
 HomeApp = app.module('home')

--- a/project_template/app/modules/home/views/detail_page.coffee
+++ b/project_template/app/modules/home/views/detail_page.coffee
@@ -1,4 +1,4 @@
-ApplicationPage = require('../../../views/application_page')
+ApplicationPage = require('app/views/application_page')
 template        = require('../templates/detail')
 
 class DetailPage extends ApplicationPage

--- a/project_template/app/modules/home/views/index_page.coffee
+++ b/project_template/app/modules/home/views/index_page.coffee
@@ -1,4 +1,4 @@
-ApplicationPage = require('../../../views/application_page')
+ApplicationPage = require('app/views/application_page')
 template        = require('../templates/index')
 $               = require('jquery')
 bus             = require('maji').bus

--- a/project_template/package.json
+++ b/project_template/package.json
@@ -22,6 +22,7 @@
     "brfs": "^1.3.0",
     "browserify": "^8.1.3",
     "coffeeify": "^1.0.0",
+    "aliasify": "^1.7.2",
     "coffeelint": "1.5.2",
     "cordova": "4.1.2",
     "envify": "^3.2.0",
@@ -44,5 +45,10 @@
     "vinyl-fs": "^0.3.13",
     "watchify": "^2.6.0",
     "yamlify": "^0.1.2"
+  },
+  "aliasify": {
+    "aliases": {
+      "app": "./app"
+    }
   }
 }


### PR DESCRIPTION
With this PR those pesky `../../../` requires are gone!

Generally it's preferable to use relative requires as much as possible as it encourages self contained modules. However often times you need to include a 'global' module from a sub module for example from any `Page` object you need to require the `application_page` module.

Before that looked something like `require('../../../views/application_page')`, with this PR that simply becomes `require('app/views/application_page')`.